### PR TITLE
feat: Allow icon object customization

### DIFF
--- a/lib/dynamic_icons.dart
+++ b/lib/dynamic_icons.dart
@@ -7,9 +7,39 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 class DynamicIcons {
   // Return Icon Based on Given Icon Name
   static double sizes = 20;
-  static dynamic getIconFromName(String name, {double size = 20}) {
+
+  static Widget? getIconFromName(String name, {
+    Color? color,
+    Key? key,
+    String? semanticLabel,
+    List<Shadow>? shadows,
+    double size = 20,
+    TextDirection? textDirection
+  }) {
     sizes = size;
-    return iconList[name];
+    Widget? icon = iconList[name];
+
+    if (icon.runtimeType == Icon) {
+      icon = Icon((icon as Icon).icon,
+        color: color,
+        key: key,
+        semanticLabel: semanticLabel,
+        shadows: shadows,
+        size: size,
+        textDirection: textDirection,
+      )
+    } else if (icon.runtimeType == FaIcon) {
+      icon = FaIcon((icon as FaIcon).icon,
+        color: color,
+        key: key,
+        semanticLabel: semanticLabel,
+        shadows: shadows,
+        size: size,
+        textDirection: textDirection,
+      )
+    }
+
+    return icon;
   }
 
   static Map<String, dynamic> iconList = {

--- a/lib/dynamic_icons.dart
+++ b/lib/dynamic_icons.dart
@@ -25,7 +25,7 @@ class DynamicIcons {
         semanticLabel: semanticLabel,
         size: size,
         textDirection: textDirection,
-      )
+      );
     } else if (icon.runtimeType == FaIcon) {
       icon = FaIcon((icon as FaIcon).icon,
         color: color,
@@ -33,7 +33,7 @@ class DynamicIcons {
         semanticLabel: semanticLabel,
         size: size,
         textDirection: textDirection,
-      )
+      );
     }
 
     return icon;

--- a/lib/dynamic_icons.dart
+++ b/lib/dynamic_icons.dart
@@ -12,7 +12,6 @@ class DynamicIcons {
     Color? color,
     Key? key,
     String? semanticLabel,
-    List<Shadow>? shadows,
     double size = 20,
     TextDirection? textDirection
   }) {
@@ -24,7 +23,6 @@ class DynamicIcons {
         color: color,
         key: key,
         semanticLabel: semanticLabel,
-        shadows: shadows,
         size: size,
         textDirection: textDirection,
       )
@@ -33,7 +31,6 @@ class DynamicIcons {
         color: color,
         key: key,
         semanticLabel: semanticLabel,
-        shadows: shadows,
         size: size,
         textDirection: textDirection,
       )


### PR DESCRIPTION
I decided to introduce more customization features to the generated `Icon`s and `FaIcon`s. Additionally, I modified the `getIconFromName()` output from `dynamic` into `Widget?` which are inherited in both `Icon`s and `FaIcon`s.

Having these icons styled on run-time makes it easy to add new icons without impacting much the library's file size, i.e. without copy-pasting all static parameters into the list.